### PR TITLE
Add naive model training and inference scripts

### DIFF
--- a/inference_model.py
+++ b/inference_model.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from models.naive_model import NaiveModel
+
+INPUT_DATA_PATH = 'mnist_784.csv'
+MODEL_PATH = 'naive_model.pkl'
+OUTPUT_DATA_PATH = 'mnist_784_predictions.csv'
+
+def main():
+    df = pd.read_csv(INPUT_DATA_PATH)
+    model = NaiveModel()
+    model.load(MODEL_PATH)
+    predictions = model.predict(df)
+    predictions.to_csv(OUTPUT_DATA_PATH, index=False)
+
+if __name__ == '__main__':
+    main()
+

--- a/models/naive_model.py
+++ b/models/naive_model.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import pickle
+from typing import Dict
+
+class NaiveModel:
+    def __init__(self):
+        self.means: Dict[str, float] = {}
+
+    def fit(self, df: pd.DataFrame) -> None:
+        """Calculate and store the mean for each column."""
+        if df is None or df.empty:
+            raise ValueError("Input DataFrame is empty")
+        self.means = df.mean().to_dict()
+
+    def predict(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return a DataFrame divided by learned column means."""
+        if not self.means:
+            raise ValueError("Model has not been fitted yet")
+        if df is None or df.empty:
+            raise ValueError("Input DataFrame is empty")
+        result = df.copy(deep=True)
+        for column, mean in self.means.items():
+            if column in result.columns and mean != 0:
+                result[column] = result[column] / mean
+        return result
+
+    def save(self, path: str) -> None:
+        """Serialize column means to disk using pickle."""
+        with open(path, 'wb') as f:
+            pickle.dump(self.means, f)
+
+    def load(self, path: str) -> None:
+        """Load column means from disk."""
+        with open(path, 'rb') as f:
+            self.means = pickle.load(f)
+

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from models.naive_model import NaiveModel
+
+DATA_PATH = 'mnist_784.csv'
+MODEL_PATH = 'naive_model.pkl'
+
+def main():
+    df = pd.read_csv(DATA_PATH)
+    model = NaiveModel()
+    model.fit(df)
+    model.save(MODEL_PATH)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- implement `NaiveModel` in `models` package
- add training script to compute and save column means
- add inference script to load the model and transform new data

## Testing
- `python -m py_compile models/naive_model.py train_model.py inference_model.py`
- `pip install pandas`
- `python - <<'PY'
import pandas as pd
from models.naive_model import NaiveModel
import os

df = pd.DataFrame({'A':[1,2,3],'B':[4,5,6]})
model = NaiveModel()
model.fit(df)
model.save('test.pkl')
model2 = NaiveModel()
model2.load('test.pkl')
print(model2.predict(df))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684ab2185ca8832fb9faf7dda4999e20