### PR TITLE
Add command dispatcher and README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # practicas
+
+This package provides utilities to train and run a naive model example.
+
+## Usage
+
+Execute the package with Python's `-m` switch and one of the available
+commands:
+
+```bash
+python -m practicas train   # train the model
+python -m practicas predict # generate predictions
+```

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,16 @@
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="practicas command dispatcher")
+    parser.add_argument('command', choices=['train', 'predict'], help='Action to perform')
+    args = parser.parse_args()
+
+    if args.command == 'train':
+        from . import train_model
+        train_model.main()
+    else:  # predict
+        from . import inference_model
+        inference_model.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement a `__main__.py` dispatcher for `train` and `predict`
- document running the package with `python -m practicas`

## Testing
- `python3 -m py_compile __main__.py inference_model.py models/__init__.py models/naive_model.py train_model.py`
- `python3 -m practicas -h`

------
https://chatgpt.com/codex/tasks/task_e_685c19508750832fa5cc29c7ccc9e608